### PR TITLE
Make setting ansible_host to IP optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,8 @@ environment: default-environment
 # Define this if a ssh jump host which is not the hypervisor is needed to reach the VM
 #bastion_host:
 
+# When provisioning, set ansible_host value to the host's internal IP address
+set_ansible_host_to_internal_ip: Yes
 
 #################################################
 # Kickstart based deployment settings ###########

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -92,6 +92,7 @@
   # This fixes things if you don't have the IP address in DNS or /etc/hosts.
 - name: Set ansible_host to the new guest IP address
   set_fact: ansible_host={{ internal_ip }}
+  when: set_ansible_host_to_internal_ip == true
 
 - name: wait for VM to become available before continuing
   wait_for:


### PR DESCRIPTION
In some cases it is desirable to not override ansible_host using the
host's internal_ip value. Make this overriding optional instead of
forcing the user to always override ansible_host.